### PR TITLE
Now builds on both Open JDK and Oracle JDK.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,16 +1,1 @@
-FROM islandora/claw-open-jdk
-MAINTAINER Nigel Banks <nigel.g.banks@gmail.com>
-
-LABEL "License"="MIT" \
-      "Version"="0.0.1"
-
-ARG MAVEN_VERSION="3.3.9"
-
-ENV M2_HOME=/opt/maven \
-    PATH=${PATH}:/opt/maven/bin
-
-RUN curl -L http://ftp.ps.pl/pub/apache/maven/maven-${MAVEN_VERSION%%.*}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
-    tar -xzf - -C /opt && \
-    mv /opt/apache-maven-${MAVEN_VERSION} ${M2_HOME}
-
-COPY rootfs /
+Dockerfile.open-jdk

--- a/Dockerfile.open-jdk
+++ b/Dockerfile.open-jdk
@@ -1,0 +1,16 @@
+FROM islandora/claw-open-jdk
+MAINTAINER Nigel Banks <nigel.g.banks@gmail.com>
+
+LABEL "License"="MIT" \
+      "Version"="0.0.1"
+
+ARG MAVEN_VERSION="3.3.9"
+
+ENV M2_HOME=/opt/maven \
+    PATH=${PATH}:/opt/maven/bin
+
+RUN curl -L http://ftp.ps.pl/pub/apache/maven/maven-${MAVEN_VERSION%%.*}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt && \
+    mv /opt/apache-maven-${MAVEN_VERSION} ${M2_HOME}
+
+COPY rootfs /

--- a/Dockerfile.oracle-jdk
+++ b/Dockerfile.oracle-jdk
@@ -1,0 +1,16 @@
+FROM islandora/claw-oracle-jdk
+MAINTAINER Nigel Banks <nigel.g.banks@gmail.com>
+
+LABEL "License"="MIT" \
+      "Version"="0.0.1"
+
+ARG MAVEN_VERSION="3.3.9"
+
+ENV M2_HOME=/opt/maven \
+    PATH=${PATH}:/opt/maven/bin
+
+RUN curl -L http://ftp.ps.pl/pub/apache/maven/maven-${MAVEN_VERSION%%.*}/${MAVEN_VERSION}/binaries/apache-maven-${MAVEN_VERSION}-bin.tar.gz | \
+    tar -xzf - -C /opt && \
+    mv /opt/apache-maven-${MAVEN_VERSION} ${M2_HOME}
+
+COPY rootfs /

--- a/README.md
+++ b/README.md
@@ -7,7 +7,8 @@
 
 Defines the Maven Docker image.
 
-Based on [OpenJDK Docker Image](https://github.com/Islandora-CLAW/claw-docker-open-jdk).
+Based on either the [OpenJDK Docker Image](https://github.com/Islandora-CLAW/claw-docker-open-jdk) or 
+[OracleJDK Docker Image](https://github.com/Islandora-CLAW/claw-docker-oracle-jdk).
 
 ## Includes
 
@@ -45,10 +46,6 @@ For convenience a number of commands are provided in the [commands](/commands) f
 | build       |           |          | Build this image with the default settings.                           |
 | run         |           | ash      | Start container, execute the given arguments as a command, then exit. |
 | mvn-install | path      | $PWD     | Perform ```mvn install``` in the given path then exit.                |
-
-## Notes
-
-Eventually we will support running on either OpenJDK or Oracle JDK, but for the moment it only supports OpenJDK.
 
 ## Maintainers/Sponsors
 

--- a/commands/build
+++ b/commands/build
@@ -1,3 +1,6 @@
 #!/bin/bash
-readonly DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )"
-docker build -t islandora/claw-maven $DIR/..
+readonly ROOT="$( cd "$( dirname "${BASH_SOURCE[0]}" )/.." && pwd )"
+docker build -f $ROOT/Dockerfile.oracle-jdk -t islandora/claw-maven:oracle-jdk $ROOT
+docker build -f $ROOT/Dockerfile.open-jdk -t islandora/claw-maven:open-jdk $ROOT
+# Open JDK is the default implementation. 
+docker tag islandora/claw-maven:open-jdk islandora/claw-maven:latest


### PR DESCRIPTION
We'll need to update Docker Hub once this is merged so it builds both Dockerfile's.